### PR TITLE
Handle dropped connections

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,6 +183,7 @@ class KeyboardSplatoon():
             self.on_drop_connection()
             
     def on_drop_connection(self):
+        self.is_game_start = False
         self.active_screen = "home"
         if self.server is not None:
             self.server.kill()

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ class KeyboardSplatoon():
 
         #Scren handler
         self.screen_handler = ScreenHandler(self.screen,WINDOW_WIDTH,WINDOW_HEIGHT,self.keys_font)
-        self.active_screen = "home"
+        self.active_screen = "splash"
         self.winner = None
 
         # self.active_screen = "gameover"

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ class KeyboardSplatoon():
 
         #Scren handler
         self.screen_handler = ScreenHandler(self.screen,WINDOW_WIDTH,WINDOW_HEIGHT,self.keys_font)
-        self.active_screen = "splash"
+        self.active_screen = "home"
         self.winner = None
 
         # self.active_screen = "gameover"
@@ -180,13 +180,16 @@ class KeyboardSplatoon():
             self.screen_handler.begin_countdown()
 
         elif msg == self.BACKHOME:
-            self.active_screen = "home"
-            if self.server is not None:
-                self.server.kill()
-                self.server = None
-            if self.client is not None:
-                self.client.kill()
-                self.client = None
+            self.on_drop_connection()
+            
+    def on_drop_connection(self):
+        self.active_screen = "home"
+        if self.server is not None:
+            self.server.kill()
+            self.server = None
+        if self.client is not None:
+            self.client.kill()
+            self.client = None
 
     #Main Play
     def play(self, event):
@@ -309,12 +312,13 @@ class KeyboardSplatoon():
 
                 if self.active_screen == "host":
                     if self.server is None:
-                        self.server = myServer()
+                        self.server = myServer(on_drop_connection=self.on_drop_connection)
                     self.client = GameClient(
                         receive_keypress=self.receive_keypress,
                         receive_keyboard_state=self.receive_keyboard_state,
                         receive_game_state=self.decode_game_state,
-                        event_listener=self.event_listener
+                        event_listener=self.event_listener,
+                        on_drop_connection=self.on_drop_connection,
                     )
                     print("Initialized Server")
                     print("Initialized Game Client")
@@ -340,7 +344,8 @@ class KeyboardSplatoon():
                                 receive_keypress=self.receive_keypress,
                                 receive_keyboard_state=self.receive_keyboard_state,
                                 receive_game_state=self.decode_game_state,
-                                event_listener=self.event_listener
+                                event_listener=self.event_listener,
+                                on_drop_connection=self.on_drop_connection,
                             )
                             self.is_client_initialized = True
                             print("Initialized Game Client")

--- a/main.py
+++ b/main.py
@@ -181,8 +181,12 @@ class KeyboardSplatoon():
 
         elif msg == self.BACKHOME:
             self.active_screen = "home"
-            self.server = None
-            self.client = None
+            if self.server is not None:
+                self.server.kill()
+                self.server = None
+            if self.client is not None:
+                self.client.kill()
+                self.client = None
 
     #Main Play
     def play(self, event):
@@ -304,7 +308,8 @@ class KeyboardSplatoon():
                 self.active_screen = self.screen_handler.switch_screen(self.active_screen, **kwargs)
 
                 if self.active_screen == "host":
-                    self.server = myServer()
+                    if self.server is None:
+                        self.server = myServer()
                     self.client = GameClient(
                         receive_keypress=self.receive_keypress,
                         receive_keyboard_state=self.receive_keyboard_state,
@@ -354,14 +359,10 @@ class KeyboardSplatoon():
                     self.screen_handler.clear_loading_inputbox()
                     self.is_client_initialized = False
 
-                    if self.server != None:
+                    if self.server is not None:
                         self.server.broadcast(self.BACKHOME.encode())
-                        self.server.kill()
-
-
-                    if self.client != None:
+                    if self.client is not None:
                         self.client.send(self.BACKHOME.encode())
-                        self.client.kill()
 
             pygame.display.update()
             GAME_CLOCK.tick(60)

--- a/network/client.py
+++ b/network/client.py
@@ -27,7 +27,7 @@ class myClient:
 
                 if not s_msg_bin:
                     print("Server disconnected. Exiting.")
-                    self.kill()
+                    self.on_drop_connection()
                     return
 
                 try:
@@ -56,10 +56,12 @@ class GameClient(myClient):
                  receive_keyboard_state,
                  receive_game_state,
                  event_listener,
+                 on_drop_connection=None,
                  host="localhost",
                  port=7634,
                  on_receive=None
                  ):
+        self.on_drop_connection = on_drop_connection
         self.receive_keypress = receive_keypress
         self.receive_keyboard_state = receive_keyboard_state
         self.receive_game_state = receive_game_state

--- a/network/client.py
+++ b/network/client.py
@@ -25,6 +25,11 @@ class myClient:
             try:
                 s_msg_bin = self.s.recv(1024)
 
+                if not s_msg_bin:
+                    print("Server disconnected. Exiting.")
+                    self.kill()
+                    return
+
                 try:
                     s_msg = s_msg_bin.decode()
                 except UnicodeDecodeError:

--- a/network/client.py
+++ b/network/client.py
@@ -48,7 +48,7 @@ class myClient:
 
     def kill(self):
         self.run = False
-        self.t_receive.join(timeout=5)
+        # self.t_receive.join(timeout=5)
 
 class GameClient(myClient):
     def __init__(self,

--- a/network/server.py
+++ b/network/server.py
@@ -5,7 +5,8 @@ import time
 
 
 class myServer:
-    def __init__(self, host="0.0.0.0", port=7634):
+    def __init__(self, on_drop_connection=None, host="0.0.0.0", port=7634):
+        self.on_drop_connection = on_drop_connection
         self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         # Prevent OSError: [Errno 98] Address already in use
         self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -92,7 +93,7 @@ class myServer:
                 c_msg_bin = conn.recv(1024)
                 if not c_msg_bin:
                     print("Client disconnected. Destroying server")
-                    self.kill()
+                    self.on_drop_connection()
                     break  # Break out of the loop when the client disconnects
 
                 try:

--- a/network/server.py
+++ b/network/server.py
@@ -87,27 +87,26 @@ class myServer:
                 self.server.close()
 
     def clientHandler(self, conn, adr):
-        try:
-            while self.serverRun:
+        while self.serverRun:
+            try:
+                c_msg_bin = conn.recv(1024)
+                if not c_msg_bin:
+                    print("Client disconnected. Destroying server")
+                    self.kill()
+                    break  # Break out of the loop when the client disconnects
+
                 try:
-                    c_msg_bin = conn.recv(1024)
-                    if not c_msg_bin:
-                        break  # Break out of the loop when the client disconnects
+                    # Decode string
+                    c_msg = c_msg_bin.decode()
+                except UnicodeDecodeError:
+                    # Decode data object
+                    c_msg = pickle.loads(c_msg_bin)
 
-                    try:
-                        # Decode string
-                        c_msg = c_msg_bin.decode()
-                    except UnicodeDecodeError:
-                        # Decode data object
-                        c_msg = pickle.loads(c_msg_bin)
-
-                    print(f"message from {adr}: {c_msg}")
-                    self.broadcast(c_msg_bin)
-                except:
-                    break  # Break out of the loop when an exception occurs (e.g., client disconnects)
-        finally:
-            print("Client disconnected. Destroying server")
-            self.kill()
+                print(f"message from {adr}: {c_msg}")
+                self.broadcast(c_msg_bin)
+            except Exception as e:
+                raise e
+                break  # Break out of the loop when an exception occurs (e.g., client disconnects)
 
     def on_client_connect(self, conn, addr):
         try:

--- a/network/server.py
+++ b/network/server.py
@@ -87,21 +87,27 @@ class myServer:
                 self.server.close()
 
     def clientHandler(self, conn, adr):
-        while self.serverRun:
-            try:
-                c_msg_bin = conn.recv(1024)
+        try:
+            while self.serverRun:
                 try:
-                    # Decode string
-                    c_msg = c_msg_bin.decode()
-                except UnicodeDecodeError:
-                    # Decode data object
-                    c_msg = pickle.loads(c_msg_bin)
+                    c_msg_bin = conn.recv(1024)
+                    if not c_msg_bin:
+                        break  # Break out of the loop when the client disconnects
+
+                    try:
+                        # Decode string
+                        c_msg = c_msg_bin.decode()
+                    except UnicodeDecodeError:
+                        # Decode data object
+                        c_msg = pickle.loads(c_msg_bin)
+
+                    print(f"message from {adr}: {c_msg}")
+                    self.broadcast(c_msg_bin)
                 except:
-                    pass
-                print(f"message from {adr}: {c_msg}")
-                self.broadcast(c_msg_bin)
-            except:
-                pass
+                    break  # Break out of the loop when an exception occurs (e.g., client disconnects)
+        finally:
+            print("Client disconnected. Destroying server")
+            self.kill()
 
     def on_client_connect(self, conn, addr):
         try:


### PR DESCRIPTION
- Fix bug where, if Player 2 drops/returns to main menu, Player 1 cannot initialize a game again
- Change logic when one player returns to main menu
  - Go back to home screen
  - Flip `is_game_start` flag
  - kill server & set to None
  - kill client & set to None
- Reuse "return to main menu" logic when a player loses connection
- Leave stupid thread alone when calling `MyClient.kill()` and hope it just fixes itself